### PR TITLE
Don't drop parent modules if used only in anonsub

### DIFF
--- a/t/C-COMPILED/issues--issue348.t
+++ b/t/C-COMPILED/issues--issue348.t
@@ -1,0 +1,1 @@
+template.pl

--- a/t/issues/issue348.t
+++ b/t/issues/issue348.t
@@ -1,0 +1,30 @@
+#!perl
+
+package Foo::Bar;
+
+sub baz {
+    return 1;
+}
+
+package Foo;
+
+sub new {
+    my ($class) = @_;
+
+    return bless {}, $class;
+}
+
+sub method {
+    return 1;
+}
+
+package main;
+
+Foo::Bar::baz();
+
+my $foo = sub {
+    Foo->new
+}->();
+
+print "1..1\n";
+printf "%s - Package Foo considered while walking anonymous subroutine\n", $foo->method ? 'ok' : 'not ok';


### PR DESCRIPTION
Issue 348: Don't drop modules declared in parent namespaces in the
presence usages of modules in child namespaces if the only usage of a
module in a parent namespace is within an anonymous subroutine

ie, if 'Foo' and 'Foo::Bar' exist, and 'Foo::Bar' is used, but 'Foo' is
only used in an anonymous subroutine, do a better job of keeping 'Foo'
