### PR TITLE
Avoid a double quote issue when using cstring for GV::save

### DIFF
--- a/lib/B/C.pm
+++ b/lib/B/C.pm
@@ -4513,7 +4513,6 @@ sub B::GV::save {
       my $cvsym;
       if ( $gvcv->XSUB and $fullname ne $origname ) {    #XSUB CONSTSUB alias
 	my $package = $gvcv->GV->EGV->STASH->NAME;
-        $origname = cstring( $origname );
         warn "Boot $package, XS CONSTSUB alias of $fullname to $origname\n" if $debug{pkg};
         mark_package($package, 1);
         {


### PR DESCRIPTION
Note that this error was hiding some segfault issues related
to mro, that now clearly occur.