### PR TITLE
utf8 stash fix for B::GV::save

### DIFF
--- a/t/testc.sh
+++ b/t/testc.sh
@@ -1172,6 +1172,12 @@ package main;
 my $f = foo->new( x => 5, y => 6);
 print $f->x . "\n";'
 result[371]='5'
+
+if [[ $v518 -gt 0 ]]; then
+  tests[372]='use utf8; require mro; my $f_gen = mro::get_pkg_gen('ᕘ'); undef %ᕘ::; mro::get_pkg_gen('ᕘ'); delete $::{"ᕘ::"}; print "ok";'
+  result[372]='ok'
+fi
+
 tests[2050]='use utf8;package 텟ţ::ᴼ; sub ᴼ_or_Ḋ { "ok" } print ᴼ_or_Ḋ;'
 result[2050]='ok'
 


### PR DESCRIPTION
This commit is fixing one utf8 issue with stash.
View test 372 added to testc.sh to reproduce the error.

Use strlen_flags helper for detecting utf8 strings and
their length. This avoids duplicate logic for unicode strings.

As a bonus this is also fixing previous calls to gv_fetchpvn
with incorrect argument number:
- gv_fetchpvn($name, "GV_ADD", "SVt_PV")
- gv_fetchpvn($name, "GV_ADD", "SVt_PVCV")