### PR TITLE
fixup for C 5.22: fix PADNAME fields

### DIFF
--- a/C.xs
+++ b/C.xs
@@ -256,7 +256,7 @@ CODE:
     RETVAL = newSVpvn_flags((char*)&items[-1], (1+len) * sizeof(UNOP_AUX_item), 0);
 OUTPUT:
     RETVAL
-          
+
 #endif
 
 #if PERL_VERSION > 17
@@ -291,6 +291,10 @@ MODULE = B	PACKAGE = B::PADNAMELIST	PREFIX = Padnamelist
 size_t
 PadnamelistMAXNAMED(padnl)
 	B::PADNAMELIST	padnl
+    CODE:
+        RETVAL = padnl->xpadnl_max_named;
+    OUTPUT:
+       RETVAL
 
 #endif
 

--- a/lib/B/C.pm
+++ b/lib/B/C.pm
@@ -2785,6 +2785,7 @@ sub B::PADNAME::save {
   }
   my $flags = $pn->FLAGS; # U8 + FAKE if OUTER
   $flags = $flags & 0xff;
+  my $is_fake = $pn->FLAGS & SVf_FAKE;
   my $gen    = $pn->GEN;
   my $stash  = $pn->OURSTASH;
   my $type   = $pn->TYPE;
@@ -2806,8 +2807,8 @@ sub B::PADNAME::save {
         $PERL522 ? 'NULL' : $cstr,
         is_constant($sn) ? "(HV*)$sn" : 'Nullhv',
         is_constant($tn) ? "(HV*)$tn" : 'Nullhv',
-        $pn->COP_SEQ_RANGE_LOW,
-        $pn->COP_SEQ_RANGE_HIGH,
+        $is_fake         ? $pn->COP_SEQ_RANGE_LOW  : 0,
+        $is_fake         ? $pn->COP_SEQ_RANGE_HIGH : 0,
         $refcnt >= 1000 ? sprintf("0x%x", $refcnt) : "$refcnt /* +1 */",
         $gen, $pn->LEN, $flags, $PERL522 ? $cstr : ()));
   if ( $PERL522 and $pn->LEN > 60 ) {


### PR DESCRIPTION
fixup for commit 52693f9
we still need to check if the SVf_FAKE is set

Without this fix, many unit tests were segfaulting