### PR TITLE
Fix several warnings during compilation time

### DIFF
--- a/t/testc.sh
+++ b/t/testc.sh
@@ -1178,6 +1178,8 @@ fi
 tests[2050]='use utf8;package 텟ţ::ᴼ; sub ᴼ_or_Ḋ { "ok" } print ᴼ_or_Ḋ;'
 tests[2051]='use utf8;package ƂƂƂƂ; sub ƟK { "ok" } package ƦƦƦƦ; use base "ƂƂƂƂ"; my $x = bless {}, "ƦƦƦƦ"; print $x->ƟK();'
 tests[2052]='{ package Diӑmond_A; sub fಓ { "ok" } } { package Diӑmond_B; use base q{Diӑmond_A}; use mro "c3"; sub fಓ { (shift)->next::method() } } print Diӑmond_B->fಓ();'
+tests[2053]='#!./perl -w
+use strict; BEGIN { $SIG{__WARN__} = sub { die "Dying on warning: ", @_ } } print q{ok}'
 
 init
 


### PR DESCRIPTION
You could legitimate try to override warnings
in your code and die if one is emitted.
We should avoid to raise warnings from B::C when we can.

This is fixing:
- redundant args in sprint in B::COP::save and output
- B::PMOP::save: Dying on warning: Invalid conversion in sprintf
- undefined nvx in B::PVNV::save