### PR TITLE
Do not use a while loop to align the length in save_pv_or_rv

### DIFF
--- a/lib/B/C.pm
+++ b/lib/B/C.pm
@@ -971,10 +971,8 @@ sub save_pv_or_rv {
     }
   }
   if ($len and $PERL518) { # COW logic
-    my $ptrsize = $Config{ptrsize};
-    while ($len % $ptrsize) { # XXX $len += $len % $ptrsize;
-      $len++;
-    }
+    my $offset = $len % $Config{ptrsize};
+    $len += $Config{ptrsize} - $offset if $offset;
   }
   warn sprintf("Saving pv %s %s cur=%d, len=%d, static=%d cow=%d %s\n", $savesym, cstring($pv), $cur, $len,
                $static, $iscow, $shared_hek ? "shared, $fullname" : $fullname) if $debug{pv};


### PR DESCRIPTION
The while loop here is not really required,
this is micro optimization rather than a fix.

Simple test:
````
> for l in $(seq 0 20); do echo '#### $l'; L=$l perl -E 'my $ptr = 8; my $len = $ENV{L}; my $l = $len; while ( $l % $ptr ) { ++$l} say $l; my $l =$len; my $off = $l % $ptr; $l += $ptr - $off if $off; say $l '; done
#### $l
0
0
#### $l
8
8
#### $l
8
8
#### $l
8
8
#### $l
8
8
#### $l
8
8
#### $l
8
8
#### $l
8
8
#### $l
8
8
#### $l
16
16
#### $l
16
16
#### $l
16
16
#### $l
16
16
#### $l
16
16
#### $l
16
16
#### $l
16
16
#### $l
16
16
#### $l
24
24
#### $l
24
24
#### $l
24
24
#### $l
24
24
````