### PR TITLE
use constant INIT failure - #238

### DIFF
--- a/lib/B/C.pm
+++ b/lib/B/C.pm
@@ -3618,7 +3618,7 @@ sub B::CV::save {
       return get_cv($fullname, 0);
     }
   }
-  if ( $cvxsub && $cvname eq "INIT" ) {
+  if ( $cvxsub && !$isconst && $cvname eq "INIT" ) {
     no strict 'refs';
     warn $fullname."\n" if $debug{sub};
     return svref_2object( \&Dummy_initxs )->save;


### PR DESCRIPTION
This is fixing the constant INIT issue,
consider to add this test to testc.sh

'use constant INIT => 5; print qq/ok\n/ if INIT == 5'