### PR TITLE
Do not use the module Config in B::C

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -1,5 +1,6 @@
 use ExtUtils::MakeMaker;
 use Config;
+use Data::Dumper;
 use File::Spec;
 use 5.006;
 use Carp;
@@ -77,7 +78,15 @@ sub write_b_c_flags {
     print PH "\$extra_cflags = \"$extra_cflags\";\n";
     print PH "\$extra_libs = \"$extra_libs\";\n";
     print PH "\@deps = qw( ", $b_c_deps, " );\n\n";
-    #print PH %Config{qw()} = ();
+
+    $Data::Dumper::Terse=1;
+    $Data::Dumper::Sortkeys=1;
+    my $conf = Dumper \%Config;
+    $conf =~ s/^\s*{/(/;
+    $conf =~ s/}\s*$/);/;
+    print PH "our \%Config = $conf\n";
+
+    print PH "\n";
     print PH "1;\n";
     close PH;
     chmod 0644, "lib/B/C/Flags.pm";

--- a/lib/B/C.pm
+++ b/lib/B/C.pm
@@ -16,7 +16,13 @@ our $VERSION = '1.52_04';
 our %debug;
 our $check;
 my $eval_pvs = '';
-use Config;
+
+our %Config;
+BEGIN {
+  use B::C::Flags;
+  *Config = \%B::C::Flags::Config;
+}
+
 # Thanks to Mattia Barbon for the C99 tip to init any union members
 my $C99 = $Config{d_c99_variadic_macros}; # http://docs.sun.com/source/819-3688/c99.app.html#pgfId-1003962
 
@@ -355,7 +361,6 @@ BEGIN {
 }
 use B::Asmdata qw(@specialsv_name);
 
-use B::C::Flags;
 use FileHandle;
 
 my $hv_index      = 0;


### PR DESCRIPTION
Instead of using Config and bloating compiled code, Simply use the generated
B::C::Flags file to store %Config values. Then do a dirty import in B::C so the
code in B::C does not have to be altered.

This should solve a class of problems related to compiling in Config into
binaries that never use Config.