### PR TITLE
Additional fixup for a620639c to keep improving #272

### DIFF
--- a/lib/B/C.pm
+++ b/lib/B/C.pm
@@ -988,6 +988,7 @@ sub save_hek {
   my ($str, $fullname, $dynamic) = @_; # not cstring'ed
   # $dynamic not yet implemented. see lexsub CvNAME in CV::save
   # force empty string for CV prototypes
+  return "NULL" unless defined $str;
   return "NULL" if !length $str and !@_ and $fullname !~ /unopaux_item.* const/;
   return $hektable{$str} if defined $hektable{$str};
   my ($cstr, $cur, $utf8) = strlen_flags($str);


### PR DESCRIPTION
Avoid a warning from save_hek when $str is undefined

$str can be undefined, and we do not want to use it as
an hash key. We have nothing to save when $str is undef.