### PR TITLE
Remove Config::launcher workaround - fixes #261

### DIFF
--- a/lib/B/C.pm
+++ b/lib/B/C.pm
@@ -3430,10 +3430,6 @@ sub try_autoload {
   my $fullname = $cvstashname . '::' . $cvname;
   warn sprintf( "No definition for sub %s. Try %s::AUTOLOAD\n",
 		$fullname, $cvstashname ) if $debug{cv};
-  # First some exceptions, fooled by goto
-  if ($cvstashname eq 'Config') {
-    return svref_2object( \&{'Config::launcher'} );
-  }
   if ($fullname eq 'utf8::SWASHNEW') {
     # utf8_heavy was loaded so far, so defer to a demand-loading stub
     my $stub = sub { require 'utf8_heavy.pl' unless $savINC{"utf8_heavy.pl"}; goto &utf8::SWASHNEW; };


### PR DESCRIPTION
Config is not compiled anymore since eab6e43, we have no reasons to trigger
Config::launcher now, this will lead to duplicate defintions:

Test:
> perlcc -r -e 'use Config; print qq/ok\n/ if $Config{ivsize}'

This commit fixes #261