### PR TITLE
Extra fix for multideref with an empty string - #249

### DIFF
--- a/lib/B/C.pm
+++ b/lib/B/C.pm
@@ -962,6 +962,7 @@ sub save_pv_or_rv {
         if ($shared_hek) {
           if ($savesym eq "emptystring") {
             $free->add("    SvLEN(&$s) = 0;") ;
+            $len = 0 if $PERL518;
           } else {
             $len = 0;
           }

--- a/t/testc.sh
+++ b/t/testc.sh
@@ -1182,6 +1182,9 @@ tests[2051]='use utf8;package ƂƂƂƂ; sub ƟK { "ok" } package ƦƦƦƦ; use b
 tests[2052]='{ package Diӑmond_A; sub fಓ { "ok" } } { package Diӑmond_B; use base q{Diӑmond_A}; use mro "c3"; sub fಓ { (shift)->next::method() } } print Diӑmond_B->fಓ();'
 tests[2053]='#!./perl -w
 use strict; BEGIN { $SIG{__WARN__} = sub { die "Dying on warning: ", @_ } } print q{ok}'
+# multideref
+tests[2054]='my %h; $h{""} = q/boom/; print qq{ok\n}'
+tests[2055]='our %h; $h{""} = q/boom/; print qq{ok\n}'
 
 init
 


### PR DESCRIPTION
We need to set length to 0 when the string is emptystring.

Provide some basic unit tests to reproduce the issue,
this only needs to be fixed for perl >= 5.18