### PR TITLE
Better handling of Infinite and NaN for doubles

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -84,7 +84,7 @@ sub write_b_c_flags {
     my %cfg;
     # Ensure to add all used Config keys in B::C here, otherwise they will be silently empty!
     # easier hash key/value slices only came with 5.22
-    for my $s (qw(archname cc ccflags d_c99_variadic_macros d_dlopen d_longdbl dlext i_dlfcn
+    for my $s (qw(archname cc ccflags d_c99_variadic_macros d_dlopen d_isinf d_isnan d_longdbl dlext i_dlfcn
                   ivdformat ivsize longsize mad nvgformat ptrsize static_ext usecperl
                   usedl useithreads uselongdouble usemultiplicity usemymalloc uvuformat))
     {

--- a/lib/B/C.pm
+++ b/lib/B/C.pm
@@ -1083,6 +1083,16 @@ sub ivx ($) {
 # protect from warning: floating constant exceeds range of ‘double’ [-Woverflow]
 sub nvx ($) {
   my $nvx = shift;
+
+  # Handle infinite and NaN values
+  if ( defined $nvx ) {
+      if ( $Config{d_isinf} ) {
+        return 'INFINITY' if $nvx eq 'Inf';
+        return '-INFINITY' if $nvx eq '-Inf';
+      }
+      return 'NAN' if $Config{d_isnan} && $nvx eq 'NaN';
+  }
+
   my $nvgformat = $Config{nvgformat};
   $nvgformat =~ s/["\0]//g; #" poor editor
   $nvgformat =~ s/".$/"/;  # cperl bug 5.22.2 #61

--- a/t/testc.sh
+++ b/t/testc.sh
@@ -1052,6 +1052,11 @@ print `cat "ccode.tmp"`'
 result[284]='123
 456
 789'
+# issue 287 with Inf and NaN
+tests[2870]='my $i = "-Inf" + 0; use B; my $sv = B::svref_2object(\$i); print qq/ok\n/ if $sv->NV eq "-Inf"'
+tests[2871]='my $i = "Inf" + 0; use B; my $sv = B::svref_2object(\$i); print qq/ok\n/ if $sv->NV eq "Inf"'
+tests[2872]='my $i = "NaN" + 0; use B; my $sv = B::svref_2object(\$i); print qq/ok\n/ if $sv->NV eq "NaN"'
+
 tests[289]='no warnings; sub z_zwap (&); print qq{ok\n} if eval q{sub z_zwap {return @_}; 1;}'
 tests[290]='sub f;print "ok" if exists &f && not defined &f;'
 tests[293]='use Coro; print q(ok)'


### PR DESCRIPTION
Case #287: positive and negative infinity are compiled as 0 value

When the C isinf and isnan are available then use libc function
to set the correct value.