### PR TITLE
Enable Stash access detection to fix testc.sh 46

### DIFF
--- a/lib/B/C.pm
+++ b/lib/B/C.pm
@@ -4288,13 +4288,14 @@ sub B::GV::save {
   my $is_special = ref($gv) eq 'B::SPECIAL';
 
   # If we come across a stash, we therefore have code using this symbol.
-  # But this does not mean that we need to save the package then.
-  # if (defined %Exporter::) should not import Exporter, it should return undef.
-  #if ( $gvname =~ m/::$/ ) {
-  #  my $package = $gvname;
-  #  $package =~ s/::$//;
-  #  mark_package($package); #wrong
-  #}
+  # If the code is loaded, then assure the package is not removed.
+  # NOTE: We're not forcing it to be loaded, we're preventing it from being removed from %INC.
+  if ( $gvname =~ m/::$/ ) {
+    my $package = $gvname;
+    $package =~ s/::$//;
+    mark_package($package); #wrong
+  }
+
   if ($fullname =~ /^(bytes|utf8)::AUTOLOAD$/) {
     $gv = force_heavy($package); # defer to run-time autoload, or compile it in?
     $sym = savesym( $gv, $sym ); # override new gv ptr to sym


### PR DESCRIPTION
This Makes it so if we have code that looks for the stash, and the stash was
present at compile time, it will also be present at run time.