### PR TITLE
main stash coulg contain some unicode functions

### DIFF
--- a/lib/B/C.pm
+++ b/lib/B/C.pm
@@ -6912,7 +6912,7 @@ sub B::GV::savecv {
   #
   return if ( $package ne 'main' and !$include_package{$package} );
   return if ( $package eq 'main' and
-	      $name =~ /^([^_A-Za-z0-9].*|_\<.*|INC|ARGV|SIG|ENV|BEGIN|main::|!)$/ );
+	      $name =~ /^([^\w].*|_\<.*|INC|ARGV|SIG|ENV|BEGIN|main::|!)$/ );
 
   warn sprintf( "Used GV \*$fullname 0x%x\n", $$gv ) if $debug{gv};
   return unless ( $$cv || $$av || $$sv || $$hv || $gv->IO || $gv->FORM );

--- a/t/testc.sh
+++ b/t/testc.sh
@@ -1239,7 +1239,8 @@ tests[317]='use Net::SSLeay();use IO::Socket::SSL();Net::SSLeay::OpenSSL_add_ssl
 tests[318]='{ local $\ = "ok" ; print "" }'
 tests[319]='#TODO Wide character warnings missing (bytes layer ignored)
 use warnings q{utf8}; my $w; local $SIG{__WARN__} = sub { $w = $_[0] }; my $c = chr(300); open F, ">", "a"; binmode(F, ":bytes:"); print F $c,"\n"; close F; print $w'
-tests[320]='#TODO No warnings reading in invalid utf8 stream (utf8 layer ignored)
+tests[320]='use utf8; sub участники { print qq{ok\n} } $::{"участники"}->()'
+tests[3200]='#TODO No warnings reading in invalid utf8 stream (utf8 layer ignored)
 use warnings "utf8"; local $SIG{__WARN__} = sub { $@ = shift }; open F, ">", "a"; binmode F; my ($chrE4, $chrF6) = (chr(0xE4), chr(0xF6)); print F "foo", $chrE4, "\n"; print F "foo", $chrF6, "\n"; close F; open F, "<:utf8", "a";  undef $@; my $line = <F>; print q(ok) if $@ =~ /utf8 "\xE4" does not map to Unicode/;'
 tests[324]='package Master;
 use mro "c3";


### PR DESCRIPTION
Issue #320: in some cases, unicode functions are not saved
as we are using a regexp to skip them.

Adjust B::GV::savecv to be more permissive.

Rename previous test 320 as 3200,
we are now providing a test case for 320.

Test the provided test with/without the patch, but also run the full testsuite to check that this change does not introduce any regressions