### PR TITLE
fix gcc warning when saving COP

### DIFF
--- a/lib/B/C.pm
+++ b/lib/B/C.pm
@@ -2212,7 +2212,7 @@ sub B::COP::save {
       # which is not the address which will be freed in S_cop_free.
       # Need to use old-style PerlMemShared_, see S_cop_free in op.c (#362)
       # lexwarn<n> might be also be STRLEN* 0
-      $init->add("if ($copw) $dest = (STRLEN*)savesharedpvn((const char*)$copw, sizeof($copw));");
+      $init->add("if (sizeof($copw)) $dest = (STRLEN*)savesharedpvn((const char*)$copw, sizeof($copw));");
     }
   } else {
     $init->add( sprintf( "cop_list[%d].cop_warnings = %s;", $ix, $warn_sv ) )


### PR DESCRIPTION
$copw is the address of the array and is always true,
we need to check the size of the array itself,
or we can simply get rid of it