### PR TITLE
Avoid a segfault when saving a PADLIST with debug on

### DIFF
--- a/lib/B/C.pm
+++ b/lib/B/C.pm
@@ -4980,7 +4980,9 @@ sub B::AV::save {
   }
 
   my ($magic, $av_index) = ('');
-  $svsect->debug($fullname, $av->flagspv) if $debug{flags};
+  # a PADLIST is tag as an AV but does not have flagspv
+  #   another option would be to define it:  *B::PADLIST::flagspv = sub { 0 }
+  $svsect->debug($fullname, ref $av eq 'B::PADLIST' ? 0 : $av->flagspv) if $debug{flags};
   if (!$ispadlist and !$ispadnamelist) {
     my $sv_ix = $svsect->index;
     $av_index = $xpvavsect->index;


### PR DESCRIPTION
Issue #120: segfault when running testc.sh -O3 91

This is a segfault which is only triggered when enabling debug...

When saving an AV, we are using $av->flagspv (only for debugging)
and earlier we flag a PADLIST as an AV...

we should not call flagspv method on a PADLIST

Tested before/after patch with: ./t/testc.sh -O3 91