### PR TITLE
Fix generation of @B::C::Config::deps on Windows

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -58,7 +58,7 @@ sub b_c_deps {
       ." -I".File::Spec->catfile(qw(.. .. lib));
     my $runperl = $X . ($CORE ? ' '.$blib : "");
     return "AnyDBM_File AutoLoader B B::AV B::Asmdata B::BINOP B::BM B::C B::C::Config B::C::InitSection B::C::Section B::CC B::COP B::CV B::FAKEOP B::FM B::GV B::HE B::HV B::INVLIST B::IO B::IV B::LEXWARN B::LISTOP B::LOGOP B::LOOP B::MAGIC B::METHOP B::NULL B::NV B::OBJECT B::OP B::PADLIST B::PADNAME B::PADNAMELIST B::PADOP B::PMOP B::PV B::PVIV B::PVLV B::PVMG B::PVNV B::PVOP B::REGEXP B::RHE B::RV B::SPECIAL B::STASHGV B::SV B::SVOP B::Section B::UNOP B::UNOP_AUX B::UV CORE CORE::GLOBAL Carp Config DB DynaLoader EV Encode Errno Exporter Exporter::Heavy ExtUtils ExtUtils::Constant ExtUtils::Constant::ProxySubs Fcntl FileHandle IO IO::File IO::Handle IO::Poll IO::Seekable IO::Socket IO::Socket::SSL Int Internals Net Net::DNS Num O POSIX PerlIO PerlIO::Layer PerlIO::scalar Regexp SelectSaver Str Symbol UInt UNIVERSAL XSConfig XSLoader __ANON__ arybase arybase::mg attributes constant coretypes int main mro num re str strict threads uint utf8 vars version warnings warnings::register Socket" if $CORE and $] > 5.020;
-    return `$runperl -Ilib -mB::C -mO -MB -e'B::C::collect_deps()'`;
+    return `$runperl -Ilib -mB::C -mO -MB -e"B::C::collect_deps()"`;
 }
 
 # does not work with miniperl


### PR DESCRIPTION
Use double quotes in generation of @B::C::Config::deps so command is interpreted properly by the Windows shell

https://github.com/rurban/perl-compiler/issues/385