### PR TITLE
Adjust CV::save logic for perl522

### DIFF
--- a/lib/B/C.pm
+++ b/lib/B/C.pm
@@ -362,7 +362,7 @@ BEGIN {
       eval q[sub PMf_ONCE(){ 0x0002 }];
     }
     if ($] > 5.021006) {
-      B->import(qw(SVf_PROTECT CVf_ANONCONST));
+      B->import(qw(SVf_PROTECT CVf_ANONCONST SVs_PADSTALE));
     } else {
       eval q[sub SVf_PROTECT(){ 0x0 }
              sub CVf_ANONCONST(){ 0x0 }]; # unused
@@ -4210,9 +4210,15 @@ sub B::CV::save {
 
   # XXX how is ANON with CONST handled? CONST uses XSUBANY [GH #246]
   if ($isconst and !is_phase_name($cvname) and
-      ( ($PERL522 and !($CvFLAGS & (CVf_ANONCONST|CVf_CONST)))
-     or (!$PERL522 and !($CvFLAGS & CVf_ANON)) )
-     ) # skip const magic blocks (Attribute::Handlers)
+    (
+      (
+        $PERL522
+        and !( $CvFLAGS & SVs_PADSTALE )
+        and !( $CvFLAGS & CVf_WEAKOUTSIDE )
+        and !( $fullname && $fullname =~ qr{^File::Glob::GLOB} and ( $CvFLAGS & (CVf_ANONCONST|CVf_CONST) )  )
+      )
+      or (!$PERL522 and !($CvFLAGS & CVf_ANON)) )
+    ) # skip const magic blocks (Attribute::Handlers)
   {
     my $stash = $gv->STASH;
     #warn sprintf("$cvstashname\::$cvname 0x%x -> XSUBANY", $CvFLAGS) if $debug{cv};


### PR DESCRIPTION
This is fixing the compilation of several core tests
and introduced only one single regression which unicode sub.

This is fixing several errors from the test coresuite, including 3 segfaults.
only introducing one single regression [uni/parser.t] for unicode subs
which is not really critical for now.

```diff
> g diff -U0 | grep -v '@@'
diff --git a/t/v5.22.0/C-COMPILED/known_errors.txt b/t/v5.22.0/C-COMPILED/known_errors.txt
index b972873..e969d49 100644
--- a/t/v5.22.0/C-COMPILED/known_errors.txt
+++ b/t/v5.22.0/C-COMPILED/known_errors.txt
-io/open.t                    PLAN      Plan was valid
-io/print.t                   PLAN      Plan was valid
-io/read.t                    PLAN      Plan was valid
-io/say.t                     PLAN      Plan was valid
+io/open.t                    TESTS     Test results:
-op/anonconst.t               SIG       Exit signal is 11 SEGV
-op/const-optree.t            SIG       Exit signal is 11 SEGV
+op/const-optree.t            PLAN      Plan was valid
-op/gv.t                      TESTS     Test results:
-op/index.t                   TESTS     Test results:
-op/my_stash.t                TESTS     Test results:
-op/smartmatch.t              TESTS     Test results:
-op/sub.t                     SIG       Exit signal is 11 SEGV
-op/taint.t                   TESTS     Test results:
-uni/gv.t                     TESTS     Test results:
-uni/lex_utf8.t               TESTS     Test results:
+uni/parser.t                 TESTS     Test results:
-xtestc/0203.t                TESTS     Output is: "encoding(cp1252)unixperlioutf8" expect "ok"
-xtestc/0229.t                TESTS     Output is: "" expect "ok"
-xtestc/0246.t                TESTS     Output is: "" expect "ok"
-xtestc/0305.t                TESTS     Output is: "" expect "ok"
```


extract from uni/parser.t [regression]
```
 sub 原 () { 1 }
 is grep({ $_ eq "\x{539f}"     } keys %::), 1, "Constant subs generate the right glob.";
 ```